### PR TITLE
#28: Fix index out of bounds exception thrown when double clicking on…

### DIFF
--- a/src/main/java/com/picimako/terra/wdio/TerraWdioPsiUtil.java
+++ b/src/main/java/com/picimako/terra/wdio/TerraWdioPsiUtil.java
@@ -137,7 +137,6 @@ public final class TerraWdioPsiUtil {
 
     /**
      * Gets whether the argument expression is a screenshot validation call.
-     * TODO: unit test
      *
      * @param expression the expression to validate
      * @return true is the expression is a screenshot validation, false otherwise

--- a/src/main/java/com/picimako/terra/wdio/toolwindow/action/CompareLatestWithReferenceScreenshotsAction.java
+++ b/src/main/java/com/picimako/terra/wdio/toolwindow/action/CompareLatestWithReferenceScreenshotsAction.java
@@ -20,6 +20,7 @@ import static com.picimako.terra.wdio.toolwindow.TerraWdioTreeNode.asScreenshot;
 import static com.picimako.terra.wdio.toolwindow.TerraWdioTreeNode.isScreenshot;
 
 import java.awt.event.KeyEvent;
+import java.util.List;
 
 import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.project.Project;
@@ -60,10 +61,13 @@ public class CompareLatestWithReferenceScreenshotsAction extends AbstractTerraWd
     @Override
     public void performAction(TerraWdioTree tree, @Nullable Project project) {
         if (tree != null && isScreenshot(tree.getLastSelectedPathComponent())) {
-            VirtualFile fileToOpen = asScreenshot(tree.getLastSelectedPathComponent()).getLatests().get(0);
-            FileEditorManager fileEditorManager = FileEditorManager.getInstance(project);
-            fileEditorManager.openFile(fileToOpen, true, fileEditorManager.isFileOpen(fileToOpen));
-            fileEditorManager.setSelectedEditor(fileToOpen, ReferenceToLatestScreenshotsPreview.EDITOR_TYPE_ID);
+            List<VirtualFile> latests = asScreenshot(tree.getLastSelectedPathComponent()).getLatests();
+            if (!latests.isEmpty()) {
+                VirtualFile fileToOpen = latests.get(0);
+                FileEditorManager fileEditorManager = FileEditorManager.getInstance(project);
+                fileEditorManager.openFile(fileToOpen, true, fileEditorManager.isFileOpen(fileToOpen));
+                fileEditorManager.setSelectedEditor(fileToOpen, ReferenceToLatestScreenshotsPreview.EDITOR_TYPE_ID);
+            }
         }
     }
 
@@ -73,7 +77,7 @@ public class CompareLatestWithReferenceScreenshotsAction extends AbstractTerraWd
     }
 
     /**
-     * Checks whether the argument keyevent's keycode corresponds to the ENTER button, essentially checking whether
+     * Checks whether the argument key event's keycode corresponds to the ENTER button, essentially checking whether
      * the user hit ENTER.
      */
     public static boolean isCompareLatestsWithReferencesShortcutKey(KeyEvent e) {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -2,7 +2,7 @@
 <idea-plugin require-restart="true">
     <name>Terra Support</name>
     <id>terra.support</id>
-    <version>0.3.0-SNAPSHOT</version>
+    <version>0.3.1-SNAPSHOT</version>
     <vendor url="https://github.com/picimako/terra-support">Tamas Balog</vendor>
     <resource-bundle>messages.TerraBundle</resource-bundle>
 


### PR DESCRIPTION
… a screenshot node without a latest version of the screenshot